### PR TITLE
[capability][changelog] An option to show only merge commits.

### DIFF
--- a/src/catkin_pkg/changelog_generator.py
+++ b/src/catkin_pkg/changelog_generator.py
@@ -48,7 +48,7 @@ from catkin_pkg.changelog_generator_vcs import Tag
 FORTHCOMING_LABEL = 'Forthcoming'
 
 
-def get_all_changes(vcs_client, skip_merges=False):
+def get_all_changes(vcs_client, skip_merges=False, only_merges=False):
     tags = _get_version_tags(vcs_client)
 
     # query all log entries per tag range
@@ -56,16 +56,16 @@ def get_all_changes(vcs_client, skip_merges=False):
     previous_tag = Tag(None)
     for tag in sorted_tags(tags):
         log_entries = vcs_client.get_log_entries(
-            from_tag=previous_tag.name, to_tag=tag.name, skip_merges=skip_merges)
+            from_tag=previous_tag.name, to_tag=tag.name, skip_merges=skip_merges, only_merges=only_merges)
         tag2log_entries[previous_tag] = log_entries
         previous_tag = tag
     log_entries = vcs_client.get_log_entries(
-        from_tag=previous_tag.name, to_tag=None, skip_merges=skip_merges)
+        from_tag=previous_tag.name, to_tag=None, skip_merges=skip_merges, only_merges=only_merges)
     tag2log_entries[previous_tag] = log_entries
     return tag2log_entries
 
 
-def get_forthcoming_changes(vcs_client, skip_merges=False):
+def get_forthcoming_changes(vcs_client, skip_merges=False, only_merges=False):
     tags = _get_version_tags(vcs_client)
     latest_tag_name = _get_latest_version_tag_name(vcs_client)
 
@@ -79,7 +79,7 @@ def get_forthcoming_changes(vcs_client, skip_merges=False):
         # ignore non-forthcoming log entries but keep version to identify injection point of forthcoming
         tag2log_entries[tag] = None
     log_entries = vcs_client.get_log_entries(
-        from_tag=from_tag.name, to_tag=to_tag.name, skip_merges=skip_merges)
+        from_tag=from_tag.name, to_tag=to_tag.name, skip_merges=skip_merges, only_merges=only_merges)
     tag2log_entries[from_tag] = log_entries
     return tag2log_entries
 

--- a/src/catkin_pkg/changelog_generator_vcs.py
+++ b/src/catkin_pkg/changelog_generator_vcs.py
@@ -186,16 +186,12 @@ class GitClient(VcsClientBase):
         if from_tag or to_tag:
             cmd.append('%s%s' % ('%s..' % to_tag if to_tag else '', from_tag if from_tag else ''))
         cmd.append('--format=format:%H')
+        if skip_merges and only_merges:
+            raise RuntimeError(MSG_ERR_OPTIONS_MERGE_CONTRADICT)
         if skip_merges:
-            if not only_merges:
-                cmd.append('--no-merges')
-            else:
-                raise RuntimeError(MSG_ERR_OPTIONS_MERGE_CONTRADICT)
+            cmd.append('--no-merges')
         if only_merges:
-            if not skip_merges:
-                cmd.append('--merges')
-            else:
-                raise RuntimeError(MSG_ERR_OPTIONS_MERGE_CONTRADICT)
+            cmd.append('--merges')
         result = self._run_command(cmd)
         if result['returncode']:
             raise RuntimeError('Could not fetch commit hashes:\n%s' % result['output'])

--- a/src/catkin_pkg/cli/generate_changelog.py
+++ b/src/catkin_pkg/cli/generate_changelog.py
@@ -44,6 +44,9 @@ def main(sysargs=None):
         '-a', '--all', action='store_true', default=False,
         help='Generate changelog for all versions instead of only the forthcoming one (only supported when no changelog file exists yet)')
     parser.add_argument(
+        '--only-merges', action='store_true', default=False,
+        help='Skip all commits but merge commits to the changelog')
+    parser.add_argument(
         '--print-root', action='store_true', default=False,
         help='Output changelog content to the console as if there would be only one package in the root of the repository')
     parser.add_argument(
@@ -66,11 +69,11 @@ def main(sysargs=None):
         # printing status messages to stderr to allow piping the changelog to a file
         if args.all:
             print('Querying all tags and commit information...', file=sys.stderr)
-            tag2log_entries = get_all_changes(vcs_client, skip_merges=args.skip_merges)
+            tag2log_entries = get_all_changes(vcs_client, skip_merges=args.skip_merges, only_merges=args.only_merges)
             print('Generating changelog output with all versions...', file=sys.stderr)
         else:
             print('Querying commit information since latest tag...', file=sys.stderr)
-            tag2log_entries = get_forthcoming_changes(vcs_client, skip_merges=args.skip_merges)
+            tag2log_entries = get_forthcoming_changes(vcs_client, skip_merges=args.skip_merges, only_merges=args.only_merges)
             print('Generating changelog files with forthcoming version...', file=sys.stderr)
         print('', file=sys.stderr)
         data = generate_changelog_file('repository-level', tag2log_entries, vcs_client=vcs_client)
@@ -106,12 +109,12 @@ def main(sysargs=None):
 
     if args.all:
         print('Querying all tags and commit information...')
-        tag2log_entries = get_all_changes(vcs_client, skip_merges=args.skip_merges)
+        tag2log_entries = get_all_changes(vcs_client, skip_merges=args.skip_merges, only_merges=args.only_merges)
         print('Generating changelog files with all versions...')
         generate_changelogs(base_path, packages, tag2log_entries, logger=logging, vcs_client=vcs_client, skip_contributors=args.skip_contributors)
     else:
         print('Querying commit information since latest tag...')
-        tag2log_entries = get_forthcoming_changes(vcs_client, skip_merges=args.skip_merges)
+        tag2log_entries = get_forthcoming_changes(vcs_client, skip_merges=args.skip_merges, only_merges=args.only_merges)
         # separate packages with/without a changelog file
         packages_without = {pkg_path: package for pkg_path, package in packages.items() if package.name in missing_changelogs}
         if packages_without:


### PR DESCRIPTION
# Branches
- Base: `master` (upstream's default dev and release)
- Target: `por_master` (forked repo's default dev and release)

# Problem this PR aims to solve

`catkin_generate_changelog` generates changlogs for all packages in a repo. It's convinient but from product development perspective I've come up with different needs.

One of them is that generated changelog is a mere list of VCS commit history per package. While that certainly helps developers, AND release maintainers who may compile the changelog upon making a release, particularly for product's context where readers are not necessarily developers so that only high level content is needed, listing all of the commits may end up creating too much human work.

In addition, that definitely makes release automation more difficult.

# Solution taken in this PR

- Add an option to show only the commits made by MR/PRs.
   - In a lot of repos, changes are merged by the repository system via "merge/pull request" feature, which internally executes VCS command, e.g. `git merge`. In Git, `git merge` leaves a single commit with title.

## Future work for the suggested approach

- Merge commit content isn't always readable and useful.
   - E.g. on Gitlab, a merge commit looks like the following. MR's URL is nicely converted to an actual working URL by `catkin_generate_changelog` with a recent change https://github.com/ros-infrastructure/catkin_pkg/pull/292, but the entire message content is too verbose.:
      ```
      Merge branch 'branch-a' into 'develop'
    
       disabled X by default
    
       See merge request org/org-sub/org-sub-sub/repo!97
      ```
- Send the finalized version to the upstream [ros-infrastructure/catkin_pkg](https://github.com/ros-infrastructure/catkin_pkg/)
   - Unit test for this new option will be most likely requested by the reviewers there.

# Example output
```
# catkin_generate_changelog  --only-merges                                                                                                                                                                                                         
Querying commit information since latest tag...
Updating forthcoming section of changelog files...
- updating 'b_data_collection/CHANGELOG.rst'
- updating 'b_sensor/b_asus/CHANGELOG.rst'
:
Done.
```
```
# git diff

:
 
diff --git a/b_support/CHANGELOG.rst b/b_support/CHANGELOG.rst
index ca6571b..6663858 100644
--- a/b_support/CHANGELOG.rst
+++ b/b_support/CHANGELOG.rst
@@ -2,6 +2,22 @@
 Changelog for package b_support
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Merge branch 'feature-enable-redundancy' into 'develop'
+  Feature enable redundancy
+  See merge request `plusone-robotics/b/b_tools!265 <https://gitlab.com/plusone-robotics/b/b_tools/-/merge_requests/265>`_
+* Merge branch 'feature-standardize-background-init-wait' into 'develop'
+  Feature standardize background init wait
+  See merge request `plusone-robotics/b/b_tools!263 <https://gitlab.com/plusone-robotics/b/b_tools/-/merge_requests/263>`_
+* Merge branch 'synch-master-dev-post350' into 'develop'
+  Synch master -> develop post 3.5.0
+  See merge request `plusone-robotics/b/b_tools!262 <https://gitlab.com/plusone-robotics/b/b_tools/-/merge_requests/262>`_
+* Merge branch 'release_3.5.0' into 'master'
+  Release 3.5.0
+  See merge request `plusone-robotics/b/b_tools!261 <https://gitlab.com/plusone-robotics/b/b_tools/-/merge_requests/261>`_
+
```
Without this option,
```
# git stash
# catkin_generate_changelog
# git diff
:
diff --git a/b_support/CHANGELOG.rst b/b_support/CHANGELOG.rst
index ca6571b..afab428 100644
--- a/b_support/CHANGELOG.rst
+++ b/b_support/CHANGELOG.rst
@@ -2,6 +2,28 @@
 Changelog for package b_support
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Merge branch 'feature-enable-redundancy' into 'develop'
+  Feature enable redundancy
+  See merge request `plusone-robotics/b/b_tools!265 <https://gitlab.com/plusone-robotics/b/b_tools/-/merge_requests/265>`_
+* Update b_trigger_pick.yaml
+* Update b_trigger_pick.yaml
+* Update b_trigger_pick.yaml
+* Merge branch 'feature-standardize-background-init-wait' into 'develop'
+  Feature standardize background init wait
+  See merge request `plusone-robotics/b/b_tools!263 <https://gitlab.com/plusone-robotics/b/b_tools/-/merge_requests/263>`_
+* Update ba_loa.yaml
+* Update ba_loa.yaml
+* Update ba_loa_place.yaml
+* Merge branch 'synch-master-dev-post350' into 'develop'
+  Synch master -> develop post 3.5.0
+  See merge request `plusone-robotics/b/b_tools!262 <https://gitlab.com/plusone-robotics/b/b_tools/-/merge_requests/262>`_
+* Merge branch 'release_3.5.0' into 'master'
+  Release 3.5.0
+  See merge request `plusone-robotics/b/b_tools!261 <https://gitlab.com/plusone-robotics/b/b_tools/-/merge_requests/261>`_
```